### PR TITLE
Fix problem with listing empty directories

### DIFF
--- a/src/main/php/peer/ftp/FtpDir.class.php
+++ b/src/main/php/peer/ftp/FtpDir.class.php
@@ -34,7 +34,7 @@ class FtpDir extends FtpEntry {
    * @throws  io.IOException in case of an I/O error
    */
   public function entries() {
-    if (null === ($list= $this->connection->listingOf($this->name))) {
+    if (null === ($list= $this->connection->listingOf($this->name, '-al'))) {
       throw new IOException('Cannot list "'.$this->name.'"');
     }
     

--- a/src/test/php/peer/ftp/unittest/IntegrationTest.class.php
+++ b/src/test/php/peer/ftp/unittest/IntegrationTest.class.php
@@ -151,6 +151,16 @@ class IntegrationTest extends \unittest\TestCase {
   }
 
   #[@test]
+  public function emptyDir() {
+    $this->conn->connect();
+    with ($r= $this->conn->rootDir()); {
+      $dir= $r->newDir('.new');
+      $this->assertInstanceOf(FtpDir::class, $dir);
+      $this->assertEquals(0, $dir->entries()->size());
+    }
+  }
+
+  #[@test]
   public function nonExistantDir() {
     $this->conn->connect();
     $this->assertFalse($this->conn->rootDir()->hasDir(':DOES_NOT_EXIST'));


### PR DESCRIPTION
This pull request fixes a bug with listing empty directories. The server we where using always returned `.` and `..` regardless of the `LIST` options, while ProFTPd only does so when supplying `-al` (see http://www.proftpd.org/docs/howto/ListOptions.html).

``` php
uses(
  'peer.ftp.FtpConnection',
  'util.log.LogCategory',
  'util.log.ConsoleAppender',
  'util.cmd.Console'
);

$c= new FtpConnection('ftp://user:pass@example.com:6200');
$c->connect();
$c->setTrace((new LogCategory('protocol'))->withAppender(new ConsoleAppender()));

Console::writeLine($c->rootDir()->getDir('/offerings/prod/auto/')->entries());
```

This should return an empty array but instead produced the following output:

```
Uncaught exception: Exception lang.reflect.TargetInvocationException (xp´runtime´Dump::main)
  at lang.reflect.Method::invoke(NULL, array[1]) [line 58 of class.php]
Caused by Exception io.IOException (Cannot list "/offerings/prod/auto/")
  at peer.ftp.FtpDir::entries() [line 1 of Dump.class.php(51) : eval()'d code]
  at <main>::eval() [line 51 of Dump.class.php]
  at xp.runtime.Dump::main(array[2]) [line 0 of StackTraceElement.class.php]
  at php.ReflectionMethod::invokeArgs(NULL, array[1]) [line 95 of Method.class.php]
```

After the fix, the output is:

```
peer.ftp.FtpEntryList(0 entries)@[
  0 => "drwxr-xr-x   2 offerings www-data        6 Apr 20 07:05 ."
  1 => "drwxr-xr-x   9 offerings www-data       90 Sep 17  2015 .."
]
```
