### PR TITLE
Default passive mode to true

### DIFF
--- a/src/main/php/peer/ftp/FtpConnection.class.php
+++ b/src/main/php/peer/ftp/FtpConnection.class.php
@@ -71,7 +71,7 @@ class FtpConnection extends \lang\Object implements Traceable {
         throw new IllegalArgumentException('Unsupported scheme "'.$this->url->getScheme().'"');
     }
 
-    switch (strtolower($this->url->getParam('passive', 'false'))) {
+    switch (strtolower($this->url->getParam('passive', 'true'))) {
       case 'true': case 'yes': case 'on': case '1':
         $this->setPassive(true);
         break;

--- a/src/test/php/peer/ftp/unittest/FtpConnectionTest.class.php
+++ b/src/test/php/peer/ftp/unittest/FtpConnectionTest.class.php
@@ -58,8 +58,8 @@ class FtpConnectionTest extends \unittest\TestCase {
   }
 
   #[@test]
-  public function passive_mode_defaults_to_false() {
-    $this->assertEquals(false, (new FtpConnection('ftp://localhost'))->passive());
+  public function passive_mode_defaults_to_true() {
+    $this->assertEquals(true, (new FtpConnection('ftp://localhost'))->passive());
   }
 
   #[@test, @values([

--- a/src/test/php/peer/ftp/unittest/IntegrationTest.class.php
+++ b/src/test/php/peer/ftp/unittest/IntegrationTest.class.php
@@ -47,7 +47,7 @@ class IntegrationTest extends \unittest\TestCase {
    * Sets up test case
    */
   public function setUp() {
-    $this->conn= new FtpConnection('ftp://test:test@'.self::$bindAddress.'?passive=1&timeout=1');
+    $this->conn= new FtpConnection('ftp://test:test@'.self::$bindAddress.'?timeout=1');
   }
 
   /**


### PR DESCRIPTION
FTP is almost always used with passive mode - only in extremely highly trusted environments would you let the FTP server connect back to the client.

Note **this is a BC break ⚠️**; labelling this as "enhancement" anyways as it's rectifying a bad design decision from back when this library was created.