### PR TITLE
Add FtpEntry::isFile() and FtpEntry::isFolder() methods

### DIFF
--- a/src/main/php/peer/ftp/FtpDir.class.php
+++ b/src/main/php/peer/ftp/FtpDir.class.php
@@ -25,6 +25,9 @@ class FtpDir extends FtpEntry {
     $normalized= '/'.trim($name, '/').'/';
     parent::__construct('//' === $normalized ? '/' : $normalized, $connection);
   }
+
+  /** Returns TRUE */
+  public function isFolder(): bool { return true; }
   
   /**
    * Returns a list of entries

--- a/src/main/php/peer/ftp/FtpEntry.class.php
+++ b/src/main/php/peer/ftp/FtpEntry.class.php
@@ -31,15 +31,15 @@ abstract class FtpEntry implements Value {
     $this->name= $name;
     $this->connection= $connection;
   }
-  
-  /**
-   * Get connection
-   *
-   * @return  peer.ftp.FtpConnection 
-   */
-  public function getConnection() {
-    return $this->connection;
-  }
+
+  /** Returns whether this is a file */
+  public function isFile(): bool { return false; }
+
+  /** Returns whether this is a folder */
+  public function isFolder(): bool { return false; }
+
+  /** @return peer.ftp.FtpConnection */
+  public function getConnection() { return $this->connection; }
 
   /**
    * Checks whether this entry exists.

--- a/src/main/php/peer/ftp/FtpEntryList.class.php
+++ b/src/main/php/peer/ftp/FtpEntryList.class.php
@@ -59,9 +59,8 @@ class FtpEntryList implements Value, IteratorAggregate {
    */
   public function asArray() {
     $dotdirs= [$this->base.'./', $this->base.'../'];
-
-    for ($i= 0, $r= [], $s= sizeof($this->list); $i < $s; $i++) {
-      $e= $this->connection->parser->entryFrom($this->list[$i], $this->connection, $this->base);
+    foreach ($this->list as $line) {
+      $e= $this->connection->parser->entryFrom($line, $this->connection, $this->base);
       in_array($e->getName(), $dotdirs) || $r[]= $e;
     }
     return $r;

--- a/src/main/php/peer/ftp/FtpFile.class.php
+++ b/src/main/php/peer/ftp/FtpFile.class.php
@@ -10,6 +10,9 @@ use io\streams\{InputStream, OutputStream, Streams};
  */
 class FtpFile extends FtpEntry implements Channel {
 
+  /** Returns TRUE */
+  public function isFile(): bool { return true; }
+
   /**
    * Delete this entry
    *

--- a/src/test/php/peer/ftp/unittest/FtpEntryListTest.class.php
+++ b/src/test/php/peer/ftp/unittest/FtpEntryListTest.class.php
@@ -65,12 +65,10 @@ class FtpEntryListTest {
   public function asArray() {
     $names= ['/secret/', '/wetter.html', '/.htaccess'];
     $classes= ['peer.ftp.FtpDir', 'peer.ftp.FtpFile', 'peer.ftp.FtpFile'];
-    $offset= 0;
 
-    foreach ($this->listFixture()->asArray() as $entry) {
+    foreach ($this->listFixture()->asArray() as $offset => $entry) {
       Assert::instance($classes[$offset], $entry);
       Assert::equals($names[$offset], $entry->getName());
-      $offset++;
     } 
   }
 

--- a/src/test/php/peer/ftp/unittest/IntegrationTest.class.php
+++ b/src/test/php/peer/ftp/unittest/IntegrationTest.class.php
@@ -84,19 +84,18 @@ class IntegrationTest extends TestCase {
     with ($root= $this->conn->rootDir()); {
       $this->assertInstanceOf(FtpDir::class, $root);
       $this->assertEquals('/', $root->getName());
+      $this->assertTrue($root->isFolder());
     }
   }
-
 
   #[Test]
   public function retrieve_root_dir_entries() {
     $this->conn->connect();
+
     $entries= $this->conn->rootDir()->entries();
     $this->assertInstanceOf(FtpEntryList::class, $entries);
     $this->assertFalse($entries->isEmpty());
-    foreach ($entries as $entry) {
-      $this->assertInstanceOf(FtpEntry::class, $entry);
-    }
+    $this->assertInstanceOf('peer.ftp.FtpEntry[]', $entries->asArray());
   }
 
   #[Test]
@@ -191,6 +190,7 @@ class IntegrationTest extends TestCase {
       $index= $htdocs->getFile('index.html');
       $this->assertInstanceOf(FtpFile::class, $index);
       $this->assertEquals('/htdocs/index.html', $index->getName());
+      $this->assertTrue($index->isFile());
     }
   }
 
@@ -202,6 +202,7 @@ class IntegrationTest extends TestCase {
       $file= $htdocs->getFile('file with whitespaces.html');
       $this->assertInstanceOf(FtpFile::class, $file);
       $this->assertEquals('/htdocs/file with whitespaces.html', $file->getName());
+      $this->assertTrue($file->isFile());
     }
   }
 


### PR DESCRIPTION
Using these, we can determine whether an entry is a file or a folder instead of doing instanceof checks. These methods are consistent with `io.Path` from XP Core.