### PR TITLE
Replace FtpListIterator with `yield` expressions

### DIFF
--- a/src/main/php/peer/ftp/FtpEntryList.class.php
+++ b/src/main/php/peer/ftp/FtpEntryList.class.php
@@ -7,13 +7,11 @@ use util\Objects;
 /**
  * List of entries on an FTP server
  *
- * @see   xp://peer.ftp.FtpDir#entries
+ * @test  peer.ftp.unittest.FtpEntryListTest
+ * @see   peer.ftp.FtpDir::entries()
  */
 class FtpEntryList implements Value, IteratorAggregate {
-  protected
-    $connection   = null,
-    $list         = [],
-    $base         = '';
+  protected $connection, $list, $base;
 
   /**
    * Constructor
@@ -30,7 +28,11 @@ class FtpEntryList implements Value, IteratorAggregate {
   
   /** Iterators over all entries */
   public function getIterator(): Traversable {
-    return new FtpListIterator($this->list, $this->connection, $this->base);
+    $dotdirs= [$this->base.'./', $this->base.'../'];
+    foreach ($this->list as $line) {
+      $e= $this->connection->parser->entryFrom($line, $this->connection, $this->base);
+      in_array($e->getName(), $dotdirs) || yield $e->getName() => $e;
+    }
   }
 
   /**

--- a/src/main/php/peer/ftp/FtpListIterator.class.php
+++ b/src/main/php/peer/ftp/FtpListIterator.class.php
@@ -5,6 +5,7 @@ use Iterator, ReturnTypeWillChange;
 /**
  * Iterator for FtpEntryList which removes "." and ".." directories
  *
+ * @deprecated
  * @see      php://language.oop5.iterations
  * @purpose  Iterator implementation
  */

--- a/src/main/php/peer/ftp/collections/FtpCollection.class.php
+++ b/src/main/php/peer/ftp/collections/FtpCollection.class.php
@@ -89,11 +89,9 @@ class FtpCollection implements IOCollection {
     if (!$this->it->valid()) return null;
 
     $entry= $this->it->current();
-    if ($entry instanceof FtpDir) {
-      $next= new FtpCollection($entry);
-    } else {
-      $next= new FtpElement($entry);
-    }
+    $this->it->next();
+
+    $next= $entry->isFile() ? new FtpElement($entry) : new FtpCollection($entry);
     $next->setOrigin($this);
     return $next;
   }

--- a/src/test/php/peer/ftp/unittest/FtpEntryListTest.class.php
+++ b/src/test/php/peer/ftp/unittest/FtpEntryListTest.class.php
@@ -1,12 +1,11 @@
 <?php namespace peer\ftp\unittest;
 
-use peer\ftp\{DefaultFtpListParser, FtpConnection, FtpEntryList, FtpListIterator};
+use peer\ftp\{DefaultFtpListParser, FtpConnection, FtpEntryList};
 use unittest\{Assert, Test};
 
 /**
  * TestCase FTP listing functionality
  *
- * @see  peer.ftp.FtpListIterator
  * @see  peer.ftp.FtpEntryList
  */
 class FtpEntryListTest {
@@ -19,7 +18,7 @@ class FtpEntryListTest {
    * @return  string[] results each element as {qualified.className}({elementName})
    */
   private function iterationOn($list) {
-    $it= new FtpListIterator($list, $this->conn);
+    $it= new FtpEntryList($list, $this->conn);
     $r= [];
     foreach ($it as $entry) {
       $r[]= nameof($entry).'('.$entry->getName().')';


### PR DESCRIPTION
...simplifying the code base by quite a bit. 

The `FtpListIterator` class is deprecated and no longer in use:

```bash
$ grep -Hrn FtpListIterator src/
src/main/php/peer/ftp/FtpListIterator.class.php:12:class FtpListIterator implements Iterator {
```